### PR TITLE
Fix crash caused by a gap in tabArray

### DIFF
--- a/src/inventory-search.ts
+++ b/src/inventory-search.ts
@@ -17,7 +17,7 @@ ig.module("nax-inventory-search.inventory-search").requires(
 			let searchTabButton = this._createTabButton(
 				"search",
 				"item-search",
-				9,
+				this.tabArray.length,
 				// @ts-ignore Enum hackery
 				"SEARCH"
 			);


### PR DESCRIPTION
Hardcoding an array value is never good
fixes #2 